### PR TITLE
Fix: Add filter to FolderPicker to fix the dialog not opening

### DIFF
--- a/DependenciesWAS/SearchFolder.xaml.cs
+++ b/DependenciesWAS/SearchFolder.xaml.cs
@@ -171,6 +171,7 @@ namespace Dependencies
 			FolderPicker folderPicker = new FolderPicker();
 
 			folderPicker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
+			folderPicker.FileTypeFilter.Add("*");
 
 			WinRT.Interop.InitializeWithWindow.Initialize(folderPicker, MainWindow.GetWindowHandle());
 


### PR DESCRIPTION
This line is required, otherwise the dialog won't appear and you will get an exception.

And btw, thanks for this awesome port!